### PR TITLE
Update obmenu-install.sh

### DIFF
--- a/obmenu-install.sh
+++ b/obmenu-install.sh
@@ -5,8 +5,8 @@ cd openbox-menu
 make
 sudo make install DESTDIR=/usr
 echo "Configuring autostart..."
-echo "" >> ~/.config/openbox/autostart.sh
-echo "## Launch openbox-menu" >> ~/.config/openbox/autostart.sh
-echo "openbox-menu lxde-applications.menu -p -o menu.xml &" >> ~/.config/openbox/autostart.sh
+echo "" >> ~/.config/openbox/autostart
+echo "## Launch openbox-menu" >> ~/.config/openbox/autostart
+echo "openbox-menu lxde-applications.menu -p -o menu.xml &" >> ~/.config/openbox/autostart
 echo "Configuring menu.xml..."
 echo '<menu id="desktop-app-menu" label="Applications" execute="cat ~/.cache/menu.xml"/>' >> "~/.config/openbox/menu.xml"


### PR DESCRIPTION
The autostart file from Openbox has lost it's ".sh" ending several versions ago. It's not needed anymore.
